### PR TITLE
The "labs:enable user-env-compile" step isn't needed anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ Next, create your own Heroku application using CL Buildpack:
     heroku create -s cedar --buildpack http://github.com/jsmpereira/heroku-buildpack-cl.git
 
 ```shell
-# Enable config vars at build time http://devcenter.heroku.com/articles/labs-user-env-compile 
-heroku labs:enable user-env-compile -a myapp
-
 # Choose implementation:
 heroku config:add CL_IMPL=sbcl
 # or


### PR DESCRIPTION
As of today, at least. Everything worked out fine without it...
